### PR TITLE
fix: Correcting gem name in GH Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build omniauth-dnanexust.gemspec
+          gem build omniauth-dnanexus.gemspec
           gem push omniauth-dnanexus-*.gem
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}


### PR DESCRIPTION
The automatic deploy to RubyGems are broken due to a typo, so fixing that.