### PR TITLE
bug: Remove trailing slashes on endpoint api calls

### DIFF
--- a/lib/omniauth/strategies/dnanexus.rb
+++ b/lib/omniauth/strategies/dnanexus.rb
@@ -40,12 +40,18 @@ module OmniAuth
 
       def raw_info
         @raw_info ||= access_token.post(
-          "#{options.dnanexus_api_endpoint}/#{access_token.params["user_id"]}/describe",
+          user_describe_endpoint,
           body: "{}",
           headers: {
             "Content-Type" => "application/json"
           }
         ).parsed
+      end
+
+      private
+
+      def user_describe_endpoint
+        "#{options.dnanexus_api_endpoint.chomp("/")}/#{access_token.params["user_id"]}/describe"
       end
     end
   end


### PR DESCRIPTION
I accidentally passed in an endpoint a api endpoint ending with a `/` & the error I got was made me think the user wasn't found.

To be extra careful, I'm going to verify the URL being passed in for API calls is accurate.